### PR TITLE
Add tests (3 init, 1 decision, 1 update)

### DIFF
--- a/apps/learning_methods/ThompsonSampling.py
+++ b/apps/learning_methods/ThompsonSampling.py
@@ -50,7 +50,8 @@ class ThompsonSampling(LearningMethodBase):
     ## the state variables need to be standardized.
     ## In addition, to initialize the prior parameters, the hyperparameters from the UI need to be transformed accordingly.
 
-    def __init__(self, features=[], standalone_parameters={}, other_parameters={}):
+    # def __init__(self, features=[], standalone_parameters={}, other_parameters={}):
+    def __init__(self, config=[]):
         super().__init__()
         self.type = "ThompsonSampling"  # this should be same as class name
         self.description = 'This is the thomson sampling algorithm definition.'
@@ -73,9 +74,53 @@ class ThompsonSampling(LearningMethodBase):
         self._default_beta_sigma0_2 = 0.1
 
 
-        self.features = features # added by mwn
-        self.standalone_parameters = standalone_parameters
-        self.other_parameters = other_parameters
+        # self.features = features # added by mwn
+        # self.standalone_parameters = standalone_parameters
+        # self.other_parameters = other_parameters
+
+        ## YS: Move initialization from test_thompson.py to TS class
+        ## create features
+        features = {}
+        key_init = 0
+        for key, value in config["covariates"].items():
+            feature = {}
+            feature['feature_name']=value['covariate_name']
+            feature['feature_parameter_alpha0_mu']=value['main_effect_prior_mean']
+            feature['feature_parameter_alpha0_sigma']=value['main_effect_prior_standard_deviation']
+            feature['feature_parameter_beta_selected_features']=value['tailoring_variable']
+            feature['feature_parameter_beta_mu']=value['interaction_coefficient_prior_mean']
+            feature['feature_parameter_beta_sigma']=value['interaction_coefficient_prior_standard_deviation']
+            ### Jane2
+            feature['feature_parameter_state_lower']=value['covariate_min_val']
+            feature['feature_parameter_state_upper']=value['covariate_max_val']
+
+            features[key_init]=feature
+            key_init+=1
+
+        self.features = features  ## added by YS
+
+        ## create standalone_parameters
+        standalone_parameters = {}
+        standalone_parameters['alpha_0_mu_bias'] = config['model_settings']['intercept_prior_mean']
+        standalone_parameters['alpha_0_sigma_bias'] = config['model_settings']['intercept_prior_standard_deviation']
+        standalone_parameters['beta_mu_bias'] = config['model_settings']['treatment_prior_mean']
+        standalone_parameters['beta_sigma_bias'] = config['model_settings']['treatment_prior_standard_deviation']
+        standalone_parameters['noise_degree'] = config['model_settings']['noise_degree_of_freedom']
+        standalone_parameters['noise_scale'] = config['model_settings']['noise_scale']
+        ### Jane2
+        standalone_parameters['min_proximal_outcome'] = config['model_settings']['min_proximal_outcome']
+        standalone_parameters['max_proximal_outcome'] = config['model_settings']['max_proximal_outcome']
+
+        self.standalone_parameters = standalone_parameters  ## added by YS
+
+        ## create other_parameters
+        other_parameters = {}
+        other_parameters['lower_clip'] = config['intervention_settings']['intervention_probability_lower_bound']
+        other_parameters['upper_clip'] = config['intervention_settings']['intervention_probability_upper_bound']
+        
+        self.other_parameters = other_parameters  ## added by YS
+
+        
         ## Jane: IMPORTANT: Eligibility is currently not implemented in ThompsonSampling.py
 
         # self.parameters = {

--- a/apps/learning_methods/ThompsonSampling.py
+++ b/apps/learning_methods/ThompsonSampling.py
@@ -403,16 +403,16 @@ class ThompsonSampling(LearningMethodBase):
         # These need to be read from the web user interface
         # I added "value" to represent what each option means in the linear regression. It's super important.
         ### Jane: The below isn't used at all... It shouldn't be set up here.
-        decision_options = [
-            {  # Index 0
-                'name': 'Do Nothing',
-                'value': 0.7,
-            },
-            {  # Index 1
-                'name': 'Send an Intervention',
-                'value': 0.3,
-            }
-        ]
+        # decision_options = [
+        #     {  # Index 0
+        #         'name': 'Do Nothing',
+        #         'value': 0.7,
+        #     },
+        #     {  # Index 1
+        #         'name': 'Send an Intervention',
+        #         'value': 0.3,
+        #     }
+        # ]
 
         # Initialize all the global parameters appropriately
         # Jane: IMPORTANT: I assume that the initialization is done in the __init__ function

--- a/apps/learning_methods/ThompsonSampling.py
+++ b/apps/learning_methods/ThompsonSampling.py
@@ -88,8 +88,9 @@ class ThompsonSampling(LearningMethodBase):
             feature['feature_parameter_alpha0_mu']=value['main_effect_prior_mean']
             feature['feature_parameter_alpha0_sigma']=value['main_effect_prior_standard_deviation']
             feature['feature_parameter_beta_selected_features']=value['tailoring_variable']
-            feature['feature_parameter_beta_mu']=value['interaction_coefficient_prior_mean']
-            feature['feature_parameter_beta_sigma']=value['interaction_coefficient_prior_standard_deviation']
+            if (feature['feature_parameter_beta_selected_features'] == 'yes'):
+                feature['feature_parameter_beta_mu']=value['interaction_coefficient_prior_mean']
+                feature['feature_parameter_beta_sigma']=value['interaction_coefficient_prior_standard_deviation']
             ### Jane2
             feature['feature_parameter_state_lower']=value['covariate_min_val']
             feature['feature_parameter_state_upper']=value['covariate_max_val']

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -169,7 +169,7 @@ hs1_continuous_not_tailoring = { # one_cv_continuous_not_tailoring
   "uuid": "2203d770-1336-4bc8-86c2-fed2238e3529"
 }
 
-heart_steps_two_covariates = {  # two_cv_binary_tailoring_continuous_not_tailoring
+hs2_binary_tailoring_continuous_not_tailoring = {  # two_cv_binary_tailoring_continuous_not_tailoring
   "algo_type": "algorithm_type",
   "covariates": {
     "39365837-e898-448d-9dfc-9367413c5add": {
@@ -233,7 +233,7 @@ heart_steps_two_covariates = {  # two_cv_binary_tailoring_continuous_not_tailori
   "uuid": "56e6a124-9b2d-46bc-b131-29c68710078a"
 }
 
-heart_steps_covariate_int = {
+hs1_int_tailoring = {
   "algo_type": "algorithm_type",
   "covariates": {
     "e20a934b-8514-44e3-8845-185b62cb3460": {
@@ -286,7 +286,7 @@ heart_steps_covariate_int = {
   "uuid": "7a1ca672-a502-4d4f-a315-edbe0de0c68a"
 }
 
-heart_steps_covariate_continuous = {
+hs1_continuous_tailoring = {
   "algo_type": "algorithm_type",
   "covariates": {
     "672a206d-69cb-4171-91b8-1e69040f5ad4": {
@@ -339,7 +339,7 @@ heart_steps_covariate_continuous = {
   "uuid": "36041837-0be3-49a6-bffd-e4d5b2d2f264"
 }
 
-heart_steps_covariate_not_tailoring_binary = {
+hs1_binary_not_tailoring = {
   "algo_type": "algorithm_type",
   "covariates": {
     "14783889-476a-4d9e-9cac-7e739e1dd197": {
@@ -392,7 +392,7 @@ heart_steps_covariate_not_tailoring_binary = {
   "uuid": "a91565e5-eb84-40a9-8c20-16cd9ed6f48a"
 }
 
-heart_steps_covariate_not_tailoring_int = {
+hs1_int_not_tailoring = {
   "algo_type": "algorithm_type",
   "covariates": {
     "ec7cc548-fc74-46ec-b233-42912f446448": {
@@ -443,7 +443,7 @@ heart_steps_covariate_not_tailoring_int = {
   "uuid": "744185a1-8494-4f19-b9cb-f92fd1a6472c"
 }
 
-heart_steps_update_point = {  # Added by YS
+hs1_update_point = {  # Added by YS
   "algo_type": "algorithm_type",
   "covariates": {
     "99167b02-95c0-4ad6-a748-91c53e3fc4df": {
@@ -500,7 +500,7 @@ heart_steps_update_point = {  # Added by YS
   "uuid": "4d6f4771-ffbe-4d55-a2b9-62707a1fb264"
 }
 
-heart_steps_decision_freq = {  # Added by YS
+hs1_decision_freq = {  # Added by YS
   "algo_type": "algorithm_type",
   "covariates": {
     "3d8a585b-dc1c-463d-a10e-749539d5782b": {

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -62,7 +62,7 @@ hs1 = {
 
 hs1_state_data = { # state data, must match covariates? # Jane: Yes
   'Location_validation_status_code': ['SUCCESS'],
-  'Location': 1,
+  'Location': 1,  # YS: What does this mean?
 }  
 
 # Create fake data

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -116,7 +116,7 @@ hs1_update_rows = [
   }
 ]
 
-heart_steps_covariate_not_tailoring = { # one_cv_continuous_not_tailoring
+hs1_continuous_not_tailoring = { # one_cv_continuous_not_tailoring
   "algo_type": "algorithm_type",
   "covariates": {
     "dc1732cf-10a9-460f-a2d7-6554778cd686": {

--- a/tests/test_thompson.py
+++ b/tests/test_thompson.py
@@ -92,54 +92,56 @@ def _update(monkeypatch, config, update_rows):
   # ^^^ are these all done?
   # TODO: test that the resulting values for tuned params are correct given the inputs
   
-  row0={
-    "id": 537, # Jane: This is the ID that can match with each decision
-    "user_id": "user1",
-    "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
-    "decision_timestamp": "2024-10-23T16:57:39Z",
-    "decision": 1,
-    "decision_probability": 0.6,
-    "proximal_outcome": 0.5,
-    "Location": 1,
-    "Location_validation_status_code": "SUCCESS",
-  }
-  row1={
-    "id": 538, 
-    "user_id": "user1",
-    "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
-    "decision_timestamp": "2024-10-23T16:57:39Z",
-    "decision": 0,
-    "decision_probability": 0.2,
-    "proximal_outcome": 0.1,
-    "Location": 1,
-    "Location_validation_status_code": "SUCCESS",
-  }
-  row2={
-    "id": 539, 
-    "user_id": "user1",
-    "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
-    "decision_timestamp": "2024-10-23T16:57:39Z",
-    "decision": 0,
-    "decision_probability": 0.3,
-    "proximal_outcome": 0.7,
-    "Location": 0,
-    "Location_validation_status_code": "SUCCESS",
-  }
-  row3={
-    "id": 540, 
-    "user_id": "user1",
-    "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
-    "decision_timestamp": "2024-10-23T16:57:39Z",
-    "decision": 0,
-    "decision_probability": 0.7,
-    "proximal_outcome": 0.1,
-    "Location": 1,
-    "Location_validation_status_code": "SUCCESS",
-  }
+  # row0={  ## YS: These are all located under test_cases.py
+  #   "id": 537, # Jane: This is the ID that can match with each decision
+  #   "user_id": "user1",
+  #   "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
+  #   "decision_timestamp": "2024-10-23T16:57:39Z",
+  #   "decision": 1,
+  #   "decision_probability": 0.6,
+  #   "proximal_outcome": 0.5,
+  #   "Location": 1,
+  #   "Location_validation_status_code": "SUCCESS",
+  # }
+  # row1={
+  #   "id": 538, 
+  #   "user_id": "user1",
+  #   "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
+  #   "decision_timestamp": "2024-10-23T16:57:39Z",
+  #   "decision": 0,
+  #   "decision_probability": 0.2,
+  #   "proximal_outcome": 0.1,
+  #   "Location": 1,
+  #   "Location_validation_status_code": "SUCCESS",
+  # }
+  # row2={
+  #   "id": 539, 
+  #   "user_id": "user1",
+  #   "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
+  #   "decision_timestamp": "2024-10-23T16:57:39Z",
+  #   "decision": 0,
+  #   "decision_probability": 0.3,
+  #   "proximal_outcome": 0.7,
+  #   "Location": 0,
+  #   "Location_validation_status_code": "SUCCESS",
+  # }
+  # row3={
+  #   "id": 540, 
+  #   "user_id": "user1",
+  #   "algo_uuid": "697e03e8-2065-4050-9c07-2ef87f2f39ce",
+  #   "decision_timestamp": "2024-10-23T16:57:39Z",
+  #   "decision": 0,
+  #   "decision_probability": 0.7,
+  #   "proximal_outcome": 0.1,
+  #   "Location": 1,
+  #   "Location_validation_status_code": "SUCCESS",
+  # }
 
   the_data_frame = pd.DataFrame(update_rows)
   ts = _initialize(monkeypatch, config)
   tuned_params = ts.update(the_data_frame)
+  # print(tuned_params.iloc[0]['degree'])
+  return tuned_params
 
 
 def test_init_hs_example(monkeypatch):
@@ -165,14 +167,16 @@ def test_init_hs_continous_not_tailoring(monkeypatch):
 # TODO: write decision tests for all example configs; need to figure out correct input_data
 
 def test_decision_1cv_binary_tailoring(monkeypatch):
-  decision, pi, status = _decision(monkeypatch, hs1, hs1_state_data)  # can't check decision (uses random number)
+  decision, pi, status = _decision(monkeypatch, hs1, hs1_state_data)  # can't check 'decision' (uses random number)
   # TODO: test correct output
   assert pi == 0.2386883044226933
   assert status == 'SUCCESS'
 
 def test_update_1cv_binary_tailoring(monkeypatch):
-  _update(monkeypatch, hs1, hs1_update_rows)
+  result = _update(monkeypatch, hs1, hs1_update_rows)
   # TODO: test correct output
+  assert result.columns[1] == 'user_id'
+  assert result.iloc[0]['degree'] == 9.0
 
 def _test_upload(monkeypatch):
   # TODO: provide example data that matches what would be expected given the HeartSteps Example config

--- a/tests/test_thompson.py
+++ b/tests/test_thompson.py
@@ -78,6 +78,8 @@ def _decision(monkeypatch, example, state_data):
 
   decision, pi, status = ts.decision(user_id, timestamp, tuned_params, input_data)
   print(pi) # just to see if it works; still need to write an actual test
+
+  return decision, pi, status
   # TODO: verify that the decision that's produced is correct given the input data, HS config, and provided values for tuned params
   ###########
   #  end test_decision()
@@ -163,8 +165,10 @@ def test_init_hs_continous_not_tailoring(monkeypatch):
 # TODO: write decision tests for all example configs; need to figure out correct input_data
 
 def test_decision_1cv_binary_tailoring(monkeypatch):
-  _decision(monkeypatch, hs1, hs1_state_data)
+  decision, pi, status = _decision(monkeypatch, hs1, hs1_state_data)  # can't check decision (uses random number)
   # TODO: test correct output
+  assert pi == 0.2386883044226933
+  assert status == 'SUCCESS'
 
 def test_update_1cv_binary_tailoring(monkeypatch):
   _update(monkeypatch, hs1, hs1_update_rows)

--- a/tests/test_thompson.py
+++ b/tests/test_thompson.py
@@ -17,42 +17,43 @@ def _initialize(monkeypatch, config):
   # can't TS just take in a project config and do all this internally?
 
 
-  ## create features
-  features = {}
-  key_init = 0
-  for key, value in config["covariates"].items():
-    feature = {}
-    feature['feature_name']=value['covariate_name']
-    feature['feature_parameter_alpha0_mu']=value['main_effect_prior_mean']
-    feature['feature_parameter_alpha0_sigma']=value['main_effect_prior_standard_deviation']
-    feature['feature_parameter_beta_selected_features']=value['tailoring_variable']
-    feature['feature_parameter_beta_mu']=value['interaction_coefficient_prior_mean']
-    feature['feature_parameter_beta_sigma']=value['interaction_coefficient_prior_standard_deviation']
-    ### Jane2
-    feature['feature_parameter_state_lower']=value['covariate_min_val']
-    feature['feature_parameter_state_upper']=value['covariate_max_val']
+  # ## create features
+  # features = {}
+  # key_init = 0
+  # for key, value in config["covariates"].items():
+  #   feature = {}
+  #   feature['feature_name']=value['covariate_name']
+  #   feature['feature_parameter_alpha0_mu']=value['main_effect_prior_mean']
+  #   feature['feature_parameter_alpha0_sigma']=value['main_effect_prior_standard_deviation']
+  #   feature['feature_parameter_beta_selected_features']=value['tailoring_variable']
+  #   feature['feature_parameter_beta_mu']=value['interaction_coefficient_prior_mean']
+  #   feature['feature_parameter_beta_sigma']=value['interaction_coefficient_prior_standard_deviation']
+  #   ### Jane2
+  #   feature['feature_parameter_state_lower']=value['covariate_min_val']
+  #   feature['feature_parameter_state_upper']=value['covariate_max_val']
 
-    features[key_init]=feature
-    key_init+=1
+  #   features[key_init]=feature
+  #   key_init+=1
 
-  ## create standalone_parameters
-  standalone_parameters = {}
-  standalone_parameters['alpha_0_mu_bias'] = config['model_settings']['intercept_prior_mean']
-  standalone_parameters['alpha_0_sigma_bias'] = config['model_settings']['intercept_prior_standard_deviation']
-  standalone_parameters['beta_mu_bias'] = config['model_settings']['treatment_prior_mean']
-  standalone_parameters['beta_sigma_bias'] = config['model_settings']['treatment_prior_standard_deviation']
-  standalone_parameters['noise_degree'] = config['model_settings']['noise_degree_of_freedom']
-  standalone_parameters['noise_scale'] = config['model_settings']['noise_scale']
-  ### Jane2
-  standalone_parameters['min_proximal_outcome'] = config['model_settings']['min_proximal_outcome']
-  standalone_parameters['max_proximal_outcome'] = config['model_settings']['max_proximal_outcome']
+  # ## create standalone_parameters
+  # standalone_parameters = {}
+  # standalone_parameters['alpha_0_mu_bias'] = config['model_settings']['intercept_prior_mean']
+  # standalone_parameters['alpha_0_sigma_bias'] = config['model_settings']['intercept_prior_standard_deviation']
+  # standalone_parameters['beta_mu_bias'] = config['model_settings']['treatment_prior_mean']
+  # standalone_parameters['beta_sigma_bias'] = config['model_settings']['treatment_prior_standard_deviation']
+  # standalone_parameters['noise_degree'] = config['model_settings']['noise_degree_of_freedom']
+  # standalone_parameters['noise_scale'] = config['model_settings']['noise_scale']
+  # ### Jane2
+  # standalone_parameters['min_proximal_outcome'] = config['model_settings']['min_proximal_outcome']
+  # standalone_parameters['max_proximal_outcome'] = config['model_settings']['max_proximal_outcome']
 
-  ## create other_parameters
-  other_parameters = {}
-  other_parameters['lower_clip'] = config['intervention_settings']['intervention_probability_lower_bound']
-  other_parameters['upper_clip'] = config['intervention_settings']['intervention_probability_upper_bound']
+  # ## create other_parameters
+  # other_parameters = {}
+  # other_parameters['lower_clip'] = config['intervention_settings']['intervention_probability_lower_bound']
+  # other_parameters['upper_clip'] = config['intervention_settings']['intervention_probability_upper_bound']
 
-  ts=ThompsonSampling(features, standalone_parameters, other_parameters)
+  # ts=ThompsonSampling(features, standalone_parameters, other_parameters)
+  ts = ThompsonSampling(config=config)
   return ts
 
 def _decision(monkeypatch, example, state_data):

--- a/tests/test_thompson.py
+++ b/tests/test_thompson.py
@@ -9,7 +9,7 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname((os.path.abspath(__file__)))))
 
 from apps.learning_methods.ThompsonSampling import ThompsonSampling
-from tests.test_cases import hs1, hs1_state_data, hs1_update_rows, heart_steps_update_point, heart_steps_decision_freq, hs1_continuous_not_tailoring
+from tests.test_cases import hs1, hs1_state_data, hs1_update_rows, hs1_update_point, hs1_decision_freq, hs1_continuous_not_tailoring, hs2_binary_tailoring_continuous_not_tailoring
 
 def _initialize(monkeypatch, config):
 
@@ -152,17 +152,22 @@ def test_init_hs_example(monkeypatch):
   assert ts._action_center_ind == np.array([[1]])  # 1 for tailoring
 
 def test_init_hs_update_point(monkeypatch):  ## YS: Currently, update point is not being used anywhere in the TS class
-  ts = _initialize(monkeypatch, heart_steps_update_point) 
+  ts = _initialize(monkeypatch, hs1_update_point) 
   # TODO: test that it was initialized as expected
 
 def test_init_hs_decision_freq(monkeypatch):  ## YS: Currently, decision freq is not being used anywhere in the TS class
-  ts = _initialize(monkeypatch, heart_steps_decision_freq)
+  ts = _initialize(monkeypatch, hs1_decision_freq)
   # TODO: test that it was initialized as expected
 
 def test_init_hs_continous_not_tailoring(monkeypatch):
   ts = _initialize(monkeypatch, hs1_continuous_not_tailoring)
   assert ts.features[0]['feature_parameter_beta_selected_features'] == 'no'  # 'yes' for tailoring, 'no' for not tailoring cov
   assert ts._action_center_ind == np.array([[0]])  # 0 for not tailoring
+
+def test_init_hs_two_binary_tailoring_continous_not_tailoring(monkeypatch):
+  ts = _initialize(monkeypatch, hs2_binary_tailoring_continuous_not_tailoring)
+  assert ts._state_dim == len(hs2_binary_tailoring_continuous_not_tailoring["covariates"].items()) 
+  assert ts._feature_name_list[1] == "(log) Prior 30 minute step count" 
 
 # TODO: write decision tests for all example configs; need to figure out correct input_data
 

--- a/tests/test_thompson.py
+++ b/tests/test_thompson.py
@@ -9,7 +9,7 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname((os.path.abspath(__file__)))))
 
 from apps.learning_methods.ThompsonSampling import ThompsonSampling
-from tests.test_cases import hs1, hs1_state_data, hs1_update_rows, heart_steps_update_point, heart_steps_decision_freq, heart_steps_covariate_not_tailoring
+from tests.test_cases import hs1, hs1_state_data, hs1_update_rows, heart_steps_update_point, heart_steps_decision_freq, hs1_continuous_not_tailoring
 
 def _initialize(monkeypatch, config):
 
@@ -142,26 +142,27 @@ def _update(monkeypatch, config, update_rows):
 
 def test_init_hs_example(monkeypatch):
   ts = _initialize(monkeypatch, hs1)
-  # TODO: test that it was initialized as expected
   assert ts._default_mu == 0
   assert ts._state_dim == len(hs1["covariates"].items())  # _state_dim should match the number of covariates
   assert ts._feature_name_list[0] == "Location"  # _feature_name_list contains 'covariate_name'
+  assert ts._action_center_ind == np.array([[1]])  # 1 for tailoring
 
-def test_init_hs_update_point(monkeypatch):
-  _initialize(monkeypatch, heart_steps_update_point)
+def test_init_hs_update_point(monkeypatch):  ## YS: Currently, update point is not being used anywhere in the TS class
+  ts = _initialize(monkeypatch, heart_steps_update_point) 
   # TODO: test that it was initialized as expected
 
-def test_init_hs_decision_freq(monkeypatch):
-  _initialize(monkeypatch, heart_steps_decision_freq)
+def test_init_hs_decision_freq(monkeypatch):  ## YS: Currently, decision freq is not being used anywhere in the TS class
+  ts = _initialize(monkeypatch, heart_steps_decision_freq)
   # TODO: test that it was initialized as expected
 
-def test_init_hs_covariate_not_tailoring(monkeypatch):
-  _initialize(monkeypatch, heart_steps_covariate_not_tailoring)
-  # now test that it was initialized as expected
+def test_init_hs_continous_not_tailoring(monkeypatch):
+  ts = _initialize(monkeypatch, hs1_continuous_not_tailoring)
+  assert ts.features[0]['feature_parameter_beta_selected_features'] == 'no'  # 'yes' for tailoring, 'no' for not tailoring cov
+  assert ts._action_center_ind == np.array([[0]])  # 0 for not tailoring
 
 # TODO: write decision tests for all example configs; need to figure out correct input_data
 
-def test_decision_1cv_binary_tailoring (monkeypatch):
+def test_decision_1cv_binary_tailoring(monkeypatch):
   _decision(monkeypatch, hs1, hs1_state_data)
   # TODO: test correct output
 

--- a/tests/test_thompson.py
+++ b/tests/test_thompson.py
@@ -141,8 +141,11 @@ def _update(monkeypatch, config, update_rows):
 
 
 def test_init_hs_example(monkeypatch):
-  _initialize(monkeypatch, hs1)
+  ts = _initialize(monkeypatch, hs1)
   # TODO: test that it was initialized as expected
+  assert ts._default_mu == 0
+  assert ts._state_dim == len(hs1["covariates"].items())  # _state_dim should match the number of covariates
+  assert ts._feature_name_list[0] == "Location"  # _feature_name_list contains 'covariate_name'
 
 def test_init_hs_update_point(monkeypatch):
   _initialize(monkeypatch, heart_steps_update_point)


### PR DESCRIPTION
1. Refactored initialization process to Thompson Sampling class. Before, it was under test_thompson.py, but now the initialization is done under __init__() in TS class.

2. Init tests: completed 3 tests (heart step example, heart step with 2 covariates, heart step with a not tailoring covariate), each test having several assert statements.
- I checked whether the default values are created correctly, state_dim dimensions are the same as intended (e.g., should be the same as the number of covariates), feature names are set, etc.
- All tests are passed, and I put comments right beside each assert statement. 

3. Decision tests: completed 1 test with 'hs1' example. The decision() in TS class returns 3 values (decision, pi, status).
- The 'status' variable is hard coded into 'SUCCESS,' and I checked that the correct value is correctly returned to the pytest. 
- The 'pi' variable returns a certain float value (0.238...), and I checked that this value is correctly returned to the pytest. 
- The 'decision' variable cannot be checked since the value depends on a random value.

4. Update tests: completed 1 test with 'hs1' example. 
- I checked the return values (e.g., name of the columns, value of a certain row) are set correctly according to the upload data.